### PR TITLE
Show notification only when _new_ notifications are detected

### DIFF
--- a/lib/octobox_notifier/system_notification.rb
+++ b/lib/octobox_notifier/system_notification.rb
@@ -8,7 +8,7 @@ module OctoboxNotifier
         return unless always || OctoboxNotifier::Config.get_bool("notification", "display")
         if unread_notifications.empty?
           TerminalNotifier.remove(:octobox)
-        elsif notification_changed && unread_notifications.size == 1
+        elsif new_notifications? && unread_notifications.size == 1
           notification = unread_notifications.first
           TerminalNotifier.notify(
             notification.title,
@@ -18,7 +18,7 @@ module OctoboxNotifier
             execute: "#{MARK_READ_AND_OPEN} '#{notification.id}' '#{notification.url}'",
             appIcon: "data:image/png;base64,#{image}",
           )
-        elsif notification_changed
+        elsif new_notifications?
           TerminalNotifier.notify(
             pluralize(unread_notifications.size, "unread item"),
             title: 'Octobox',
@@ -53,8 +53,8 @@ module OctoboxNotifier
         "#{n} #{str}#{'s' unless n == 1}"
       end
 
-      def notification_changed
-        current_ids != previous_ids
+      def new_notifications?
+        !(current_ids - previous_ids).empty?
       end
 
       def current_ids

--- a/lib/octobox_notifier/system_notification.rb
+++ b/lib/octobox_notifier/system_notification.rb
@@ -54,7 +54,7 @@ module OctoboxNotifier
       end
 
       def new_notifications?
-        !(current_ids - previous_ids).empty?
+        (current_ids - previous_ids).any?
       end
 
       def current_ids


### PR DESCRIPTION
Otherwise, every time I mark one notif as read, it pops a new notification until there are none left.

Note that this used to be the behaviour.