### PR TITLE
Fetch up to 100 notifications

### DIFF
--- a/lib/octobox_notifier/commands/bitbar.rb
+++ b/lib/octobox_notifier/commands/bitbar.rb
@@ -16,7 +16,7 @@ module OctoboxNotifier
       def notifications
         @notifications ||= begin
           resp = CLI::Kit::Util.begin do
-            OctoboxNotifier::API.get( "/notifications.json")
+            OctoboxNotifier::API.get( "/notifications.json?per_page=100")
           end.retry_after(OpenSSL::SSL::SSLError, retries: 3)
           JSON.parse(resp.body).fetch('notifications').map { |data| OctoboxNotifier::Notification.new(data) }
         end


### PR DESCRIPTION
Otherwise, I often end up at "20", which is misleading.

Found at https://octobox.io/docs/NotificationsController.html#index-instance_method