### PR TITLE
Handle cases where the state of the PR is unknown

### DIFF
--- a/lib/octobox_notifier/notification.rb
+++ b/lib/octobox_notifier/notification.rb
@@ -84,7 +84,7 @@ module OctoboxNotifier
       when Each[COMMIT,       ANY,    ANY   ] ; "templateImage=#{Image.get('commit')}"
       when Each[RELEASE,      ANY,    ANY   ] ; "templateImage=#{Image.get('release')}"
       when Each[ALERT,        ANY,    ANY   ] ; "templateImage=#{Image.get('alert')}"
-      else                                    ; raise "Unknown type, state, draft combo: #{type}, #{state}, #{draft}"
+      else                                    ; raise "Unknown type, state, draft combo: #{type}, #{state}, #{draft?} for #{url}"
       end
     end
 

--- a/lib/octobox_notifier/notification.rb
+++ b/lib/octobox_notifier/notification.rb
@@ -81,6 +81,7 @@ module OctoboxNotifier
       when Each[PULL_REQUEST, OPEN,   ANY   ] ; "image=#{Image.get('pr', Image::GREEN)}"
       when Each[PULL_REQUEST, CLOSED, ANY   ] ; "image=#{Image.get('pr', Image::RED)}"
       when Each[PULL_REQUEST, MERGED, ANY   ] ; "image=#{Image.get('pr', Image::PURPLE)}"
+      when Each[PULL_REQUEST, ANY,    ANY   ] ; "image=#{Image.get('pr', Image::GREEN)}"
       when Each[COMMIT,       ANY,    ANY   ] ; "templateImage=#{Image.get('commit')}"
       when Each[RELEASE,      ANY,    ANY   ] ; "templateImage=#{Image.get('release')}"
       when Each[ALERT,        ANY,    ANY   ] ; "templateImage=#{Image.get('alert')}"


### PR DESCRIPTION
- For some reason, Shopify/dev#3883 was returning a `nil` state for me.
- Future proofs against new states.
- Fix `draft` unknown variable when raising